### PR TITLE
fix: typo in mapcheck args

### DIFF
--- a/plugin/ollama.vim
+++ b/plugin/ollama.vim
@@ -226,10 +226,10 @@ function! PluginInit() abort
         if empty(mapcheck('<C-]>', 'i'))
             imap <C-]> <Plug>(ollama-dismiss)
         endif
-        if empty(mapcheck('<M-Right', 'i'))
+        if empty(mapcheck('<M-Right>', 'i'))
             imap <M-Right> <Plug>(ollama-insert-line)
         endif
-        if empty(mapcheck('<M-C-Right', 'i'))
+        if empty(mapcheck('<M-C-Right>', 'i'))
             imap <M-C-Right> <Plug>(ollama-insert-word)
         endif
         if empty(mapcheck('<leader>r', 'v'))


### PR DESCRIPTION
Noticed some typos in the recent changes, this PR fixes them.