### PR TITLE
Allow unsetting the tab mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+doc/tags

--- a/README.md
+++ b/README.md
@@ -157,4 +157,9 @@ them, just continue typing or press `<C-]>` to dismiss the suggestion.
 You can also accept just the one line using `<M-Right>` (Alt-Right) or one word
 using `<M-C-Right>` (Alt-Ctrl-Right) if you don't want to use the complete suggestion.
 
+To unmap tab as insertion key so you can use your own remaps set this global variable in your `.vimrc`.
+```
+let g:ollama_unmap_tab = v:true
+```
+
 See `:help vim-ollama` for more information.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ call plug#end()
 
 Since V0.4, the plugin includes a setup wizard that helps you set up your
 initial configuration. This is especially useful for new users who are not
-familiar with Ollama or the different LLMs available as Open Source.
+familiar with Ollama or the different Open Source LLMs available.
 
 The plugin will run the wizard automatically if the configuration file
 `~/.vim/config/ollama.vim` does not yet exist. If you want to start the wizard

--- a/doc/vim-ollama.txt
+++ b/doc/vim-ollama.txt
@@ -210,11 +210,11 @@ You can configure vim-ollama using the following variables in your .vimrc:
         let g:ollama_context_lines = 10
 <
 5. g:ollama_debounce_time
-    - Description: Sets the delay after the last keystroke before triggering
-      a new search. Using smaller values give you faster reaction times, but
-      create higher load on the system. Small values make only sense on fast
-      GPU based LLMs, where the LLM computation time is not much longer than
-      the debounce time.
+    - Description: Sets the delay after the last keystroke before triggering a
+      new search. Using smaller values give you faster reaction times, but
+      creates a higher load on the system. Smaller values only make sense on
+      faster GPU based LLMs where computation time is not much longer than the
+      debounce time.
     - Default: 500 ms
     - Example:
 >
@@ -228,8 +228,9 @@ You can configure vim-ollama using the following variables in your .vimrc:
         let g:ollama_chat_model = 'gpt4-turbo'
 <
 7. g:ollama_chat_systemprompt
-    - Description: Allows overriding the system prompt of the chat model.
-    - Default: ''. If not specified the built-in prompt will be used.
+    - Description: Allows overriding the system prompt of the chat model. If
+      not specified the models default system prompt will be used.
+    - Default: ''
     - Example:
 >
         let g:ollama_chat_systemprompt = 'You are a coding assistant. Output

--- a/doc/vim-ollama.txt
+++ b/doc/vim-ollama.txt
@@ -292,6 +292,16 @@ You can configure vim-ollama using the following variables in your .vimrc:
         let g:ollama_no_maps = 1
 <
 
+13. g:ollama_unmap_tab
+    - Description: Variable, which if set to anything, will unmap tab as the
+      suggestion insertion key.
+    - Default: undefined
+    - Example:
+>
+        let g:ollama_unmap_tab = v:true
+        inoremap ,- <Plug>(ollama-insert-word)
+        inoremap ,c <Plug>(ollama-insert-line)
+
 ==============================================================================
 7. Troubleshooting                                    *vim-ollama-troubleshooting*
 

--- a/plugin/ollama.vim
+++ b/plugin/ollama.vim
@@ -109,10 +109,12 @@ function! s:HandleTabCompletion() abort
         " ignore tab in chat buffer
         return "\<Tab>"
     endif
-    let suggestion = ollama#InsertSuggestion()
-    if suggestion != '\t'
-        " AI suggestion was inserted
-        return ''
+    if !exists('g:ollama_unmap_tab')
+      let suggestion = ollama#InsertSuggestion()
+      if suggestion != '\t' 
+          " AI suggestion was inserted
+          return ''
+      endif
     endif
     call ollama#logger#Info("Forward <tab> to original mapping: ". string(g:ollama_original_tab_mapping))
 


### PR DESCRIPTION
This would increase compatibility and also make the plugin more modular. I prefer to use tab to cycle through Coc suggestions rather than AI suggestions. Combining this variable with g:ollama_no_maps would make it possible to completely customize mappings for end-users.

I've been testing this for about 2 weeks and haven't run into any issues with it.