### PR TITLE
Use the model's template (`ollama show --template <model>`)

### DIFF
--- a/python/complete.py
+++ b/python/complete.py
@@ -17,44 +17,7 @@ DEFAULT_OPTIONS = '{ "temperature": 0, "top_p": 0.95 }'
 # create logger
 log = None
 
-def load_config(modelname):
-    # Get the directory where the Python script resides
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    # Construct the full path to the config file relative to the script directory
-    config_path = os.path.join(script_dir, "configs", f"{modelname}.json")
-    try:
-        with open(config_path, 'r') as file:
-            config = json.load(file)
-            return config
-    except FileNotFoundError:
-        log.error(f"Config file {config_path} not found.")
-        sys.exit(1)
-
-# config.json example:
-# {
-#     "pre": "<PRE> ",
-#     "middle": " <MIDDLE>",
-#     "suffix": " <SUFFIX>",
-#     "eot": " <EOT>"
-# }
-def fill_in_the_middle(config, prompt):
-    """
-    Searches for the string '<FILL_IN_HERE>' in the prompt and
-    creates a model specific fill-in-the-middle-prompt.
-    """
-    parts = prompt.split('<FILL_IN_HERE>')
-    log.debug(parts)
-
-    if len(parts) != 2:
-        log.error("Prompt does not contain '<FILL_IN_HERE>'.")
-        sys.exit(1)
-
-    newprompt = config["pre"] + parts[0] + config["suffix"] + parts[1] + config["middle"]
-    log.debug(newprompt)
-
-    return newprompt
-
-def generate_code_completion(config, prompt, baseurl, model, options):
+def generate_code_completion(prompt, baseurl, model, options):
     headers = {
         'Content-Type': 'application/json',
         'Accept': '*/*',
@@ -64,11 +27,12 @@ def generate_code_completion(config, prompt, baseurl, model, options):
     log.debug('endpoint: ' + endpoint)
 
     # generate model specific prompt
-    prompt = fill_in_the_middle(config, prompt)
+    prompt, suffix = prompt.split('<FILL_IN_HERE>')
 
     data = {
         'model': model,
         'prompt': prompt,
+        'suffix': suffix,
         'stream': False,
         'raw' : True,
         'options': options
@@ -81,17 +45,9 @@ def generate_code_completion(config, prompt, baseurl, model, options):
         json_response = response.json()
         log.debug('response: ' + json.dumps(json_response, indent=4))
         completion = response.json().get('response')
-        log.info('completion:' + completion)
+        log.info('completion: ' + completion)
 
-        # find index of sub string
-        try:
-            index = completion.find(config.get('eot', '<EOT>'))
-            if index != -1:
-                completion = completion[:index] # remove EOT marker
-        except:
-            pass
-
-        return completion.rstrip()
+        return completion.strip()
     else:
         raise Exception(f"Error: {response.status_code} - {response.text}")
 
@@ -114,11 +70,6 @@ if __name__ == "__main__":
     except:
         options = DEFAULT_OPTIONS
 
-    # strip suffix (e.g ':7b-code') from modelname
-    modelname = args.model
-    modelname = modelname.rsplit(':', 1)[0]
-    config = load_config(modelname)
-
     prompt = sys.stdin.read()
-    response = generate_code_completion(config, prompt, args.url, args.model, options)
+    response = generate_code_completion(prompt, args.url, args.model, options)
     print(response, end='')


### PR DESCRIPTION
This is to fix #52 .

I've tested it with:
```
starcoder2
qwen2.5-coder
deepseek-coder-v2
codegemma
codellama
```

Do you agree? I think it might be interesting to put some templates in the repo showing how to use FIM for larger models that don't natively support it, but may be good at following instructions.