### PR TITLE
Add support for vim with dynamically linked python

### DIFF
--- a/plugin/ollama.vim
+++ b/plugin/ollama.vim
@@ -18,7 +18,7 @@ if has('nvim')
     finish
 endif
 
-if has('python3')
+if has('python3') || has('python3_dynamic')
     " Use system's python3 by default (can be changed by venv)
     let g:ollama_python_interpreter = 'python3'
 else


### PR DESCRIPTION
Allows use on opensuse and probably everywhere with 
```
vim --version | grep python
-python
+python3/dyn
```