### PR TITLE
Add g:ollama_suggestion_indicator to display when suggestions are ready.

### DIFF
--- a/autoload/ollama.vim
+++ b/autoload/ollama.vim
@@ -191,7 +191,13 @@ function! ollama#UpdatePreview(suggestion)
     call ollama#logger#Debug("UpdatePreview: suggestion='".json_encode(a:suggestion)."'")
     if !empty(a:suggestion)
         let s:suggestion = a:suggestion
-        let text = split(s:suggestion, "\r\n\\=\\|\n", 1)
+        let text = []
+        if exists('g:ollama_suggestion_indicator')
+            let text = [g:ollama_suggestion_indicator]
+        else
+            let text = split(a:suggestion, "\r\n\\=\\|\n", 1)
+        endif
+
         if empty(text[-1])
             call remove(text, -1)
         endif


### PR DESCRIPTION
This change respects a new global config value, `g:ollama_suggestion_indicator`, containing a string to display in lieu of the normally inline suggestion.

I created this change for my own use but want to offer it as a quick little thing.  I found the inline suggestion display a bit distracting while coding, so I created this.