### PR TITLE
CodeEditor: DEFAULT_HOST: Use localhost

### DIFF
--- a/python/CodeEditor.py
+++ b/python/CodeEditor.py
@@ -16,7 +16,6 @@ log = None
 
 # Default values
 DEFAULT_HOST = 'http://localhost:11434'
-DEFAULT_HOST = 'http://tux:11434'
 DEFAULT_MODEL = 'qwen2.5-coder:14b'
 DEFAULT_OPTIONS = '{ "temperature": 0, "top_p": 0.95 }'
 CONTEXT_LINES = 10


### PR DESCRIPTION
It is probably a typo that `tux` is set as the value for `DEFAULT_HOST`.