### PR TITLE
Release a job object for the suggestion process

### DIFF
--- a/autoload/ollama.vim
+++ b/autoload/ollama.vim
@@ -107,6 +107,7 @@ function! s:HandleExit(job, exit_code)
             echom "Check if g:ollama_host=".g:ollama_host." is correct."
             echohl None
         else
+            let s:kill_job = v:null
             call ollama#logger#Debug("Process terminated as expected")
         endif
         call ollama#ClearPreview()


### PR DESCRIPTION
`s:job` is being set to `v:null` already, but `s:kill_job` might still be holding a reference to the job object.

This is not a big leak, as we can hold a maximum of one reference.