### PR TITLE
Switching to installed python when vim is not compiled with +python3

### DIFF
--- a/autoload/ollama/edit.vim
+++ b/autoload/ollama/edit.vim
@@ -5,6 +5,31 @@ let s:buf = -1
 " avoid starting a 2nd edit job while one is in progress
 let g:edit_in_progress = 0
 
+if !exists('g:ollama_embedded_python') || g:ollama_embedded_python == 0
+  function! ollama#edit#EditCodeDone(status) abort
+    echoerr "OllamaEdit features require Vim compiled with +python3 support."
+  endfunction
+  function! ollama#edit#DialogCallback(id, result) abort
+    echoerr "OllamaEdit features require Vim compiled with +python3 support."
+  endfunction
+  function! ollama#edit#UpdateProgress(popup) abort
+    echoerr "OllamaEdit features require Vim compiled with +python3 support."
+  endfunction
+  function! ollama#edit#EditCode(request) abort
+    echoerr "OllamaEdit features require Vim compiled with +python3 support."
+  endfunction
+  function! ollama#edit#EditPrompt() abort
+    echoerr "OllamaEdit features require Vim compiled with +python3 support."
+  endfunction
+  function! ollama#edit#AcceptAll() abort
+    echoerr "OllamaEdit features require Vim compiled with +python3 support."
+  endfunction
+  function! ollama#edit#RejectAll() abort
+    echoerr "OllamaEdit features require Vim compiled with +python3 support."
+  endfunction
+  finish
+endif
+
 " Define the VimScript callback function
 " This will be called from python when to operations is 'done'
 " or aborted with 'error'
@@ -212,4 +237,3 @@ finally:
     pass
 EOF
 endfunction
-

--- a/plugin/ollama.vim
+++ b/plugin/ollama.vim
@@ -19,13 +19,12 @@ if has('nvim')
 endif
 
 if has('python3') || has('python3_dynamic')
-    " Use system's python3 by default (can be changed by venv)
-    let g:ollama_python_interpreter = 'python3'
+    let g:ollama_embedded_python = 1
 else
-    let g:ollama_enabled = 0
-    echom "warning: your Vim version does not support python3. Vim-ollama is disabled."
-    finish
+    let g:ollama_embedded_python = 0
 endif
+" Use system's python3 by default (can be changed by venv)
+let g:ollama_python_interpreter = 'python3'
 
 " Default settings
 if !exists('g:ollama_enabled')


### PR DESCRIPTION
I usually work with preinstalled versions of vim which doesn't have `+python3` compiled, I see that in this case the plugin is fully disabled.

This PR will switch to the python version installed in the system in case embedded python is not found and only `OllamaEdit` will be disabled (error messages are displayed if the user tries to use it).