### PR TITLE
TriggerCompletion: Do not react to {g,b}:ollama_enable

### DIFF
--- a/autoload/ollama.vim
+++ b/autoload/ollama.vim
@@ -41,9 +41,6 @@ endif
 
 function! ollama#TriggerCompletion()
     call ollama#logger#Debug("TriggerCompletion...")
-    if !ollama#IsEnabled()
-        return
-    endif
     " get current buffer type
     if &buftype=='prompt'
         call ollama#logger#Debug("Ignoring prompt buffer")


### PR DESCRIPTION
It seems a bit strange that an explicit completion request would be disabled if `g:ollama_enable` is `v:false`, or `b:ollama_enable` is `v:false`.

I think if a user is explicitly asking for a completion, it should be provided.
Chat and editing commands are not affected by `g:ollama_enable`.

I guess, it is a question of what exactly `g:ollama_enable` means.
Though, it does not seem useful to disable functionality that is not automatic.

Perhaps, it would be better to rename `g:ollama_enable` to `g:ollama_completion_automatic_enable` to be more explicit about the meaning of this setting.

Or, if there is really a use case for a flag that disables all the vim-ollama functionality without disabling the plugin itself, it should probably then affect all the functions of the plugin.
But one can just disable the plugin to achieve the same effect, it seems?