### PR TITLE
doc: No numbered lists, tags for commands and variables

### DIFF
--- a/doc/vim-ollama.txt
+++ b/doc/vim-ollama.txt
@@ -60,7 +60,8 @@ for adding comments, translating text, refactoring code and much more.
 
 The vim-ollama plugin provides the following commands:
 
-1. :Ollama
+                                                      *:Ollama*
+:Ollama
     - Description: Sends commands to the plugin to change its state.
     Available commands are:
       - `setup`: Starts the Vim-Ollama setup wizard.
@@ -81,12 +82,14 @@ The vim-ollama plugin provides the following commands:
 >
         :Ollama disable
 <
-2. :OllamaChat
+                                                      *:OllamaChat*
+:OllamaChat
     - Description: Creates a split windows for interactive conversations with
     the configured chat model. Use `:bd` to delete the chat buffer when you
     don't need anymore.
 
-3. :OllamaReview
+                                                      *:OllamaReview*
+:OllamaReview
     - Description: Reviews the selected text. It opens a chat window like
     OllamaChat, but with a predefined prompt that asks for a code review of
     the selected text. The selection may be a few lines, a function or the
@@ -96,7 +99,8 @@ The vim-ollama plugin provides the following commands:
 >
         :OllamaReview
 <
-4. :OllamaSpellCheck
+                                                      *:OllamaSpellCheck*
+:OllamaSpellCheck
     - Description: Checks the selected text for spelling errors.
     Like OllamaReview this command using the OllamaChat window but with a
     predefined prompt for spell checking. The selection may be a few lines, a
@@ -106,7 +110,8 @@ The vim-ollama plugin provides the following commands:
 >
         :OllamaSpellCheck
 <
-5. :OllamaTask
+                                                      *:OllamaTask*
+:OllamaTask
     - Description: Creates a chat window with a custom prompt. This command
     also works on a range like `:OllamaReview` but takes an additional
     argument for the prompt. The selected range will automatically pasted
@@ -119,7 +124,8 @@ The vim-ollama plugin provides the following commands:
 >
         :OllamaTask "check spelling of this text"
 <
-6. :OllamaEdit
+                                                      *:OllamaEdit*
+:OllamaEdit
     - Description: Allows editing a selected text using the AI. This command
     works on a range and so can use the whole file `:%OllamaEdit <prompt>` or
     a visual selection. Alternatively, you can use the mapping `<leader>e` to
@@ -140,7 +146,8 @@ The vim-ollama plugin provides the following commands:
     using the keys 'y', 'Y' and reject using 'n' or 'N'. Pressing Esc and 'x'
     works like pressing 'n'. `
 
-7. :OllamaPull
+                                                      *:OllamaPull*
+:OllamaPull
     - Description: Pulls a new model. This works like `ollama pull` command
     but via the REST API and the configured `g:ollama_host` URL, so you can use
     this to pull new models on remote machines, without needing to SSH in to
@@ -193,21 +200,24 @@ Other Maps ~
 
 You can configure vim-ollama using the following variables in your .vimrc:
 
-1. g:ollama_host
+                                                      *g:ollama_host*
+g:ollama_host
     - Description: Sets the Ollama host address and port.
     - Default: 'http://localhost:11434'
     - Example:
 >
         let g:ollama_host = 'http://your-server:port'
 <
-2. g:ollama_model
+                                                      *g:ollama_model*
+g:ollama_model
     - Description: Sets the default Ollama model for code completions.
     - Default: 'codellama:code'
     - Example:
 >
         let g:ollama_model = 'deepseek-coder-v2:16b-lite-base-q4_0'
 <
-3. g:ollama_model_options
+                                                      *g:ollama_model_options*
+g:ollama_model_options
     - Description: Sets the default Ollama model options.
     - Default: '{"temperature": 0, "top_p": 0.95}'
     - Example:
@@ -218,7 +228,8 @@ You can configure vim-ollama using the following variables in your .vimrc:
                 \ 'num_predict': 256
                 \ }
 <
-4. g:ollama_context_lines
+                                                      *g:ollama_context_lines*
+g:ollama_context_lines
     - Description: Sets the number of context lines before and after the
       cursor to be transmitted to the LLM for tab completion.
       When running a LLM locally on CPU (without GPU support), reduce this
@@ -228,7 +239,8 @@ You can configure vim-ollama using the following variables in your .vimrc:
 >
         let g:ollama_context_lines = 10
 <
-5. g:ollama_debounce_time
+                                                      *g:ollama_debounce_time*
+g:ollama_debounce_time
     - Description: Sets the delay after the last keystroke before triggering
       a new search. Using smaller values give you faster reaction times, but
       create higher load on the system. Small values make only sense on fast
@@ -241,14 +253,16 @@ You can configure vim-ollama using the following variables in your .vimrc:
 >
         let g:ollama_debounce_time = 300
 <
-6. g:ollama_chat_model
+                                                      *g:ollama_chat_model*
+g:ollama_chat_model
     - Description: Sets the default Ollama model to use for interactive chats.
     - Default: 'llama3'
     - Example:
 >
         let g:ollama_chat_model = 'gpt4-turbo'
 <
-7. g:ollama_chat_systemprompt
+                                                  *g:ollama_chat_systemprompt*
+g:ollama_chat_systemprompt
     - Description: Allows overriding the system prompt of the chat model. If
       not specified the models default system prompt will be used.
     - Default: ''
@@ -257,7 +271,8 @@ You can configure vim-ollama using the following variables in your .vimrc:
         let g:ollama_chat_systemprompt = 'You are a coding assistant. Output
         only code, no explanations.'
 <
-8. g:ollama_chat_options
+                                                      *g:ollama_chat_options*
+g:ollama_chat_options
     - Description: Sets the default Ollama model options for chat models.
     - Default: '{"temperature": 0, "top_p": 0.95}'
     - Example:
@@ -267,21 +282,24 @@ You can configure vim-ollama using the following variables in your .vimrc:
                 \ 'top_p': 0.95
                 \ }
 <
-9. g:ollama_chat_timeout
+                                                      *g:ollama_chat_timeout*
+g:ollama_chat_timeout
     - Description: Sets the timeout value in chat requests.
     - Default: 10
     - Example:
 >
         let g:ollama_chat_timeout = 10
 <
-10. g:ollama_edit_model
+                                                      *g:ollama_edit_model*
+g:ollama_edit_model
     - Description: Sets the default Ollama model to use for code editing.
     - Default: 'qwen2.5-coder:7b'
     - Example:
 >
         let g:ollama_chat_model = 'qwen2.5-coder:7b'
 <
-11. g:ollama_edit_options
+                                                      *g:ollama_edit_options*
+g:ollama_edit_options
     - Description: Sets the default Ollama model options for code edit models.
     - Default: '{"temperature": 0, "top_p": 0.95}'
     - Example:
@@ -292,7 +310,8 @@ You can configure vim-ollama using the following variables in your .vimrc:
                 \ 'num_predict': 256
                 \ }
 <
-12. g:ollama_use_inline_diff
+                                                      *g:ollama_use_inline_diff*
+g:ollama_use_inline_diff
     - Description: When true, the `OllamaEdit` changes are applied as inline
       diff which can be accepted or rejected individually in an interactive
       way. When false, the plugin will apply the changes directly without
@@ -304,7 +323,8 @@ You can configure vim-ollama using the following variables in your .vimrc:
 >
         let g:ollama_use_inline_diff = 0
 <
-13. g:ollama_no_maps
+                                                      *g:ollama_no_maps*
+g:ollama_no_maps
     - Description: Disables all default mappings except for `<tab>` which has
       a built-in fallback mechanism. This can be useful to avoid conflicts
       with other plugins and to define your own mappings for vim-ollama.
@@ -313,7 +333,8 @@ You can configure vim-ollama using the following variables in your .vimrc:
 >
         let g:ollama_no_maps = 1
 <
-14. g:ollama_no_tab_map
+                                                      *g:ollama_no_tab_map*
+g:ollama_no_tab_map
     - Description: If this variable is defined, the default <tab> mapping
       will not be created.
     - Default: undefined
@@ -324,7 +345,8 @@ You can configure vim-ollama using the following variables in your .vimrc:
         inoremap ,w <Plug>(ollama-insert-word)
         inoremap ,l <Plug>(ollama-insert-line)
 <
-15. g:ollama_use_venv
+                                                      *g:ollama_use_venv*
+g:ollama_use_venv
     - Description: Enables the usage of python virtual environments for
       executing the required python scripts. If enabled it will install
       the required packages automatically in this vim-ollama specific
@@ -335,7 +357,8 @@ You can configure vim-ollama using the following variables in your .vimrc:
 >
         let g:ollama_use_venv = 1
 <
-16. g:ollama_split_vertically
+                                                    *g:ollama_split_vertically*
+g:ollama_split_vertically
     - Description: When this variable is defined and set to 1 the OllamaChat
       command will create a vertical split, otherwise a horizontal split is
       used.
@@ -350,7 +373,8 @@ You can configure vim-ollama using the following variables in your .vimrc:
 
 You can enable logging by specifying the following variables.
 
-1. g:ollama_debug
+                                                      *g:ollama_debug*
+g:ollama_debug
     - Description: Sets the debug level of the logging infrastructure.
     - Levels: 0 (Off), 1 (Errors), 2 (Warnings), 3 (Info), 4 (Debug)
       Higher levels also include all lower levels.
@@ -358,8 +382,9 @@ You can enable logging by specifying the following variables.
     - Example:
 >
         let g:ollama_debug = 4
-
-2. g:ollama_logfile
+<
+                                                      *g:ollama_logfile*
+g:ollama_logfile
     - Description: Configure the path of the log file.
       Note that the log file path of the python code is currently hardcoded to
       '/tmp/logs'.
@@ -368,8 +393,9 @@ You can enable logging by specifying the following variables.
     - Example:
 >
         let g:ollama_logfile = '/path/to/vim-ollama.log'
-
-3. g:ollama_review_logfile
+<
+                                                      *g:ollama_review_logfile*
+g:ollama_review_logfile
     - Description: Configure the path for logging chat conversations.
       This only will be logged on _Debug_ level (4).
     - Default: A random file in your temp directory will be created using


### PR DESCRIPTION
Numbered lists for individual commands and variables need to be updated manually each time a command or a variable is added or removed.  Which creates a noticeable maintenance when changes are published in parallel.

Users are unlikely to use these numbers, as it is much more convenient to reference commands and global variables by their names.  Plus order in these lists is quite subjective.

Vim documentation only numbers top level sections.

At the same time, it does make sense to add tags to allow users to quickly find commands and global variables via the `:help` completion.