### PR TITLE
Use `..` for string concatenation

### DIFF
--- a/autoload/ollama/config.vim
+++ b/autoload/ollama/config.vim
@@ -70,7 +70,7 @@ endfunction
 " Handles errors from the async job
 function! ollama#config#HandleJobError(channel, msg) abort
     if !empty(a:msg)
-        echoerr "Error: " . a:msg
+        echoerr "Error: " .. a:msg
     endif
 endfunction
 

--- a/autoload/ollama/edit.vim
+++ b/autoload/ollama/edit.vim
@@ -50,7 +50,7 @@ function! ollama#edit#UpdateProgress(popup)
     " Cycle through progress states
     let g:progress_indicator = (g:progress_indicator + 1) % 4
     let l:states = ['|', '/', '-', '\']
-    call popup_settext(a:popup, 'Processing ' . l:states[g:progress_indicator])
+    call popup_settext(a:popup, 'Processing ' .. l:states[g:progress_indicator])
 
     " Poll the job status, because Vim calls from worker threads produce
     " segfaults

--- a/autoload/ollama/logger.vim
+++ b/autoload/ollama/logger.vim
@@ -4,7 +4,7 @@
 " This file is based on the code of copilot.vim, but was modified to fit
 " vim-ollams's needs.
 if !exists('g:ollama_logfile')
-    let g:ollama_logfile = tempname() . '-ollama.log'
+    let g:ollama_logfile = tempname() .. '-ollama.log'
 endif
 if !exists('g:ollama_debug')
     let g:ollama_debug = 0
@@ -30,7 +30,7 @@ endfunction
 
 function! ollama#logger#CreateFile() abort
   try
-    "echom 'created log file '.g:ollama_logfile
+    "echom 'created log file ' .. g:ollama_logfile
     call writefile([], g:ollama_logfile)
   catch
   endtry
@@ -55,7 +55,7 @@ function! ollama#logger#Raw(level, message) abort
      return
   endif
   let lines = type(a:message) == v:t_list ? copy(a:message) : split(a:message, "\n", 1)
-  let lines[0] = strftime('[%Y-%m-%d %H:%M:%S] ') . get(s:level_prefixes, a:level, '[UNKNOWN] ') . get(lines, 0, '')
+  let lines[0] = strftime('[%Y-%m-%d %H:%M:%S] ') .. get(s:level_prefixes, a:level, '[UNKNOWN] ') .. get(lines, 0, '')
   try
     if filewritable(g:ollama_logfile)
       call writefile(lines, g:ollama_logfile, 'a')

--- a/autoload/ollama/review.vim
+++ b/autoload/ollama/review.vim
@@ -5,7 +5,7 @@ let s:buf = -1
 let s:ollama_bufname = 'Ollama Chat'
 
 if !exists('g:ollama_review_logfile')
-    let g:ollama_review_logfile = tempname() . '-ollama-review.log'
+    let g:ollama_review_logfile = tempname() .. '-ollama-review.log'
 endif
 
 func! ollama#review#KillChatBot()
@@ -25,14 +25,14 @@ func! ollama#review#KillChatBot()
 endfunc
 
 func! s:BufReallyDelete(buf)
-    call ollama#logger#Debug("BufReallyDelete ".a:buf)
-    execute "bwipeout! ".a:buf
+    call ollama#logger#Debug("BufReallyDelete " .. a:buf)
+    execute "bwipeout! " .. a:buf
 endfunc
 
 func! ollama#review#BufDelete(buf)
     call ollama#logger#Debug("BufDelete")
     if a:buf == s:buf
-        call ollama#logger#Debug("Deleting buffer ".a:buf)
+        call ollama#logger#Debug("Deleting buffer " .. a:buf)
         " The buffer was closed by :quit or :q!
         call ollama#review#KillChatBot()
         " Undo 'buftype=prompt' and make buffer deletable
@@ -58,7 +58,7 @@ endfunction
 function! s:StartChat(lines) abort
     " Function handling a line of text that has been typed.
     func! TextEntered(text)
-        call ollama#logger#Debug("TextEntered: ".a:text)
+        call ollama#logger#Debug("TextEntered: " .. a:text)
         if a:text == ''
             " don't send empty messages
             return
@@ -69,7 +69,7 @@ function! s:StartChat(lines) abort
 
     " Function handling output from the shell: Add it above the prompt.
     func! GotOutput(channel, msg)
-        call ollama#logger#Debug("GotOutput: ".a:msg)
+        call ollama#logger#Debug("GotOutput: " .. a:msg)
 
         " append lines
         let l:lines = split(a:msg, "\n")
@@ -77,7 +77,7 @@ function! s:StartChat(lines) abort
             " when we received <EOT> start insert mode again
             let l:idx = stridx(l:line, "<EOT>")
             if l:idx != -1
-                call ollama#logger#Debug("idx=".l:idx)
+                call ollama#logger#Debug("idx=" .. l:idx)
                 let l:line = strpart(l:line, 0, l:idx)
             endif
             call appendbufline(s:buf, "$", l:line)
@@ -98,7 +98,7 @@ function! s:StartChat(lines) abort
 
     " Function handling output from the shell: Add it above the prompt.
     func! GotErrors(channel, msg)
-        call ollama#logger#Debug("GotErrors: ".a:msg)
+        call ollama#logger#Debug("GotErrors: " .. a:msg)
 
         let l:bufname = 'stderr'
         let l:bufnr = bufnr(l:bufname)
@@ -116,7 +116,7 @@ function! s:StartChat(lines) abort
 
     " Function handling the shell exits: close the window.
     func! JobExit(job, status)
-        call ollama#logger#Debug("JobExit: ".a:status)
+        call ollama#logger#Debug("JobExit: " .. a:status)
         " Switch to the chat buffer
         execute 'buffer' s:buf
         " Turn off prompt functionality and make the buffer modifiable
@@ -124,7 +124,7 @@ function! s:StartChat(lines) abort
         setlocal buftype=
         setlocal modifiable
         " output info message
-        call append(line("$") - 1, "Chat process terminated with exit code ".a:status)
+        call append(line("$") - 1, "Chat process terminated with exit code " .. a:status)
         call append(line("$") - 1, "Use ':q' or ':bd' to delete this buffer and run ':OllamaChat' again to create a new session.")
         stopinsert
         let s:buf = -1
@@ -133,8 +133,8 @@ function! s:StartChat(lines) abort
     endfunc
 
     let l:model_options = json_encode(g:ollama_chat_options)
-    call ollama#logger#Debug("Connecting to Ollama on ".g:ollama_host." using model ".g:ollama_model)
-    call ollama#logger#Debug("model_options=".l:model_options)
+    call ollama#logger#Debug("Connecting to Ollama on " .. g:ollama_host .. " using model " .. g:ollama_model)
+    call ollama#logger#Debug("model_options=" .. l:model_options)
 
     " Convert plugin debug level to python logger levels
     let l:log_level = ollama#logger#PythonLogLevel(g:ollama_debug)
@@ -171,7 +171,7 @@ function! s:StartChat(lines) abort
         let l:chat_win = s:FindBufferWindow(s:buf)
         " switch to existing buffer
         if l:chat_win != -1
-            execute l:chat_win . 'wincmd w'
+            execute l:chat_win  ..  'wincmd w'
         else
             execute 'buffer' s:buf
         endif
@@ -179,7 +179,7 @@ function! s:StartChat(lines) abort
         if a:lines isnot v:null
             call append(line("$") - 1, a:lines)
             let l:prompt = join(a:lines, "\n")
-            call ollama#logger#Debug("Sending prompt '".l:prompt."'...")
+            call ollama#logger#Debug("Sending prompt '" .. l:prompt .. "'...")
             call ch_sendraw(s:job, l:prompt .. "\n")
         endif
         return
@@ -243,10 +243,10 @@ function! s:StartChatWithContext(prompt, start_line, end_line) abort
     let ft = &filetype !=# '' ? &filetype : 'plaintext'
 
     " Create prompt with context of code
-    let prompt_lines = ['"""', a:prompt, "```" . ft] + lines + ["```", '"""']
+    let prompt_lines = ['"""', a:prompt, "```"  ..  ft] + lines + ["```", '"""']
 
     " Debug output for prompt
-    call ollama#logger#Debug("Prompt:\n" . join(prompt_lines, "\n"))
+    call ollama#logger#Debug("Prompt:\n"  ..  join(prompt_lines, "\n"))
 
     " Start chat (ensure this function is defined elsewhere)
     call s:StartChat(prompt_lines)

--- a/autoload/ollama/setup.vim
+++ b/autoload/ollama/setup.vim
@@ -25,8 +25,9 @@ function! ollama#setup#GetModels(url)
 
     " Check for errors during the execution
     if v:shell_error != 0
-        echom "Error: Failed to fetch models from " . a:url . ". Check if the URL is correct, Ollama is running and try again."
-        "echoerr "Output: " . l:output
+        echom "Error: Failed to fetch models from " .. a:url .. ". "
+              \ .. "Check if the URL is correct, Ollama is running and try again."
+        "echoerr "Output: " .. l:output
         return [ 'error' ]
     endif
 
@@ -37,7 +38,7 @@ endfunction
 " Process Pull Model stdout
 function! s:PullOutputCallback(job_id, data)
     if !empty(a:data)
-        call ollama#logger#Debug("Pull Output: " . a:data)
+        call ollama#logger#Debug("Pull Output: " .. a:data)
         let l:output = split(a:data, '\\n')
 
         " Update the popup with progress
@@ -51,12 +52,12 @@ endfunction
 function! s:PullErrorCallback(job_id, data)
     if !empty(a:data)
         " Log the error
-        call ollama#logger#Error("Pull Error: " . a:data)
+        call ollama#logger#Error("Pull Error: " .. a:data)
         let l:output = split(a:data, '\\n')
 
         " Display the error in the popup
         if exists('s:popup_id') && s:popup_id isnot v:null
-            call popup_settext(s:popup_id, 'Error: ' . l:output)
+            call popup_settext(s:popup_id, 'Error: ' .. l:output)
         endif
     endif
 endfunction
@@ -71,7 +72,7 @@ endfunction
 
 " Process pull process exit code
 function! s:PullExitCallback(job_id, exit_code)
-    call ollama#logger#Debug("PullExitCallback: ". a:exit_code)
+    call ollama#logger#Debug("PullExitCallback: " .. a:exit_code)
     if a:exit_code == 0
         " Log success
         call ollama#logger#Debug("Pull job completed successfully.")
@@ -82,7 +83,7 @@ function! s:PullExitCallback(job_id, exit_code)
         endif
     else
         " Log failure
-        call ollama#logger#Error("Pull job failed with exit code: " . a:exit_code)
+        call ollama#logger#Error("Pull job failed with exit code: " .. a:exit_code)
 
         " Update the popup with failure message
         if exists('s:popup_id') && s:popup_id isnot v:null
@@ -106,7 +107,7 @@ function! ollama#setup#PullModel(url, model)
     let l:command = [ g:ollama_python_interpreter, l:script_path, '-u', a:url, '-m', a:model ]
 
     " Log the command being run
-    call ollama#logger#Debug("command=". join(l:command, " "))
+    call ollama#logger#Debug("command=" .. join(l:command, " "))
 
     " Define job options
     let l:job_options = {
@@ -125,7 +126,7 @@ function! ollama#setup#PullModel(url, model)
     endif
 
     " Create a popup window for progress
-    let s:popup_id = popup_dialog('Pulling model: ' . a:model . '\n', {
+    let s:popup_id = popup_dialog('Pulling model: ' .. a:model .. '\n', {
                 \ 'padding': [0, 1, 0, 1],
                 \ 'zindex': 1000
                 \ })
@@ -134,7 +135,7 @@ function! ollama#setup#PullModel(url, model)
     let s:popup_model = a:model
 
     " Start the new job and keep a reference to it
-    call ollama#logger#Debug("Starting pull job for model: " . a:model)
+    call ollama#logger#Debug("Starting pull job for model: " .. a:model)
     let s:pull_job = job_start(l:command, l:job_options)
 endfunction
 
@@ -163,9 +164,10 @@ function! ollama#setup#SelectModel(kind, models, default)
     " Select model
     while 1
         if l:default_idx == -1
-            let l:msg = "Choose " . a:kind . " model: "
+            let l:msg = "Choose " .. a:kind .. " model: "
         else
-            let l:msg = "Choose " . a:kind . " model (Press enter for '" . a:default . "'): "
+            let l:msg = "Choose " .. a:kind .. " model "
+                  \ .. "(Press enter for '" .. a:default .. "'): "
         endif
         let l:ans = input(l:msg)
         echon "\n"
@@ -187,7 +189,9 @@ endfunction
 function! ollama#setup#Setup()
     " setup default local URL
     "let g:ollama_host = "http://localhost:11434"
-    let l:ans = input("The default Ollama base URL is '" . g:ollama_host . "'. Do you want to change it? (y/N): ")
+    let l:ans = input(
+          \ "The default Ollama base URL is '" .. g:ollama_host .. "'. "
+          \ .. "Do you want to change it? (y/N): ")
     if tolower(l:ans) == 'y'
         let g:ollama_host = input("Enter Ollama base URL: ")
     endif
@@ -243,17 +247,17 @@ function! ollama#setup#Setup()
         " Do not pull, select existing models
         let l:ans = ollama#setup#SelectModel("tab completion", l:models, "starcoder2:3b")
         let g:ollama_model = l:models[l:ans - 1]
-        echon "Configured '" . g:ollama_model . "' as tab completion model.\n"
-        echon "------------------------------------------------------------\n"
+        echon "Configured '" .. g:ollama_model .. "' as tab completion model.\n"
+        echon repeat("-", 80) .. "\n"
 
         let l:ans = ollama#setup#SelectModel("code edit", l:models, "qwen2.5-coder:7b")
         let g:ollama_edit_model = l:models[l:ans - 1]
-        echon "Configured '" . g:ollama_edit_model . "' as code edit model.\n"
-        echon "------------------------------------------------------------\n"
+        echon "Configured '" .. g:ollama_edit_model .. "' as code edit model.\n"
+        echon repeat("-", 80) .. "\n"
 
         let l:ans = ollama#setup#SelectModel("chat", l:models, "llama3.1:8b")
         let g:ollama_chat_model = l:models[l:ans - 1]
-        echon "Configured '" . g:ollama_chat_model . "' as chat model.\n"
+        echon "Configured '" .. g:ollama_chat_model .. "' as chat model.\n"
     endif
 
     call s:ExecuteNextSetupTask()
@@ -285,16 +289,16 @@ function! s:FinalizeSetupTask()
     if !isdirectory(l:config_dir)
         call mkdir(l:config_dir, 'p') " Create the directory if it doesn't exist
     endif
-    let l:config_file = l:config_dir . '/ollama.vim'
+    let l:config_file = l:config_dir .. '/ollama.vim'
 
     " Write the configuration to the file
     let l:config = [
                 \ "\" Use Python virtual environment (and install packages via pip)",
-                \ "let g:ollama_use_venv = " . g:ollama_use_venv,
+                \ "let g:ollama_use_venv = " .. g:ollama_use_venv,
                 \ "\" Ollama base URL",
-                \ "let g:ollama_host = '" . g:ollama_host . "'",
+                \ "let g:ollama_host = '" .. g:ollama_host .. "'",
                 \ "\" tab completion model",
-                \ "let g:ollama_model = '" . g:ollama_model . "'",
+                \ "let g:ollama_model = '" .. g:ollama_model .. "'",
                 \ "\" number of context lines to use for code completion",
                 \ "\"let g:ollama_context_lines = 10",
                 \ "\" debounce time to wait before triggering a completion",
@@ -307,12 +311,12 @@ function! s:FinalizeSetupTask()
                 \ "\"let g:ollama_completion_denylist_filetype = []",
                 \ "",
                 \ "\" chat model",
-                \ "let g:ollama_chat_model = '" . g:ollama_chat_model . "'",
+                \ "let g:ollama_chat_model = '" .. g:ollama_chat_model .. "'",
                 \ "\" override chat system prompt",
                 \ "\"let g:ollama_chat_systemprompt = 'Give funny answers.'",
                 \ "",
                 \ "\" edit model",
-                \ "let g:ollama_edit_model = '" . g:ollama_edit_model . "'",
+                \ "let g:ollama_edit_model = '" .. g:ollama_edit_model .. "'",
                 \ "\" when disabled, LLM changs are applied directly. Useful when tracking changes via Git.",
                 \ "\"let g:ollama_use_inline_diff = 0",
                 \ "",
@@ -325,7 +329,7 @@ function! s:FinalizeSetupTask()
                 \ "",
                 \ "\" vim: filetype=vim.ollama" ]
     call writefile(l:config, l:config_file)
-    echon "Configuration saved to " . l:config_file . "\n"
+    echon "Configuration saved to " .. l:config_file .. "\n"
     call popup_notification("Setup complete", #{ pos: 'center'})
 endfunction
 
@@ -348,7 +352,7 @@ endfunction
 " Install all dependencies using Pip
 function! ollama#setup#PipInstall() abort
     let l:venv_path = expand('$HOME/.vim/venv/ollama')
-    let l:pip_path = l:venv_path . '/bin/pip'
+    let l:pip_path = l:venv_path .. '/bin/pip'
     let l:reqs = ["'httpx>=0.23.3'", 'requests', 'jinja2']
 
     if !g:ollama_use_venv
@@ -363,7 +367,7 @@ function! ollama#setup#PipInstall() abort
     endif
 
     echon "Installing dependencies...\n"
-    call system(l:pip_path . ' install ' . join(l:reqs, ' '))
+    call system(l:pip_path .. ' install ' .. join(l:reqs, ' '))
     echon "Dependencies installed successfully.\n"
 endfunction
 
@@ -374,14 +378,14 @@ function! ollama#setup#EnsureVenv() abort
     " Check if virtual environment already exists
     if !isdirectory(l:venv_path)
         echon "Setting up Python virtual environment for Vim-Ollama...\n"
-        call system('python3 -m venv ' . shellescape(l:venv_path))
+        call system('python3 -m venv ' .. shellescape(l:venv_path))
         echon "Succeeded.\n"
 
         call ollama#setup#PipInstall()
     endif
 
     " Change path to python to venv
-    let g:ollama_python_interpreter = l:venv_path . '/bin/python'
+    let g:ollama_python_interpreter = l:venv_path .. '/bin/python'
 endfunction
 
 " Loads the plugin's python modules
@@ -432,7 +436,7 @@ if use_venv:
             #print(f'Adding venv site-packages to path: {venv_site_packages}')
             sys.path.insert(0, venv_site_packages)
     else:
-        print('Venv not found: '. venv_path)
+        print('Venv not found: ' + venv_path)
 else:
     print('Venv disabled')
 EOF

--- a/plugin/ollama.vim
+++ b/plugin/ollama.vim
@@ -140,14 +140,14 @@ function! s:HandleTabCompletion() abort
         call ollama#logger#Info("Forward <tab> to original mapping: ". string(g:ollama_original_tab_mapping))
         if g:ollama_original_tab_mapping.rhs =~# '^<Plug>'
             call ollama#logger#Info("<tab> feedkeys")
-            call feedkeys("\<Plug>" . matchstr(g:ollama_original_tab_mapping.rhs, '^<Plug>\zs.*'), 'm')
+            call feedkeys("\<Plug>" .. matchstr(g:ollama_original_tab_mapping.rhs, '^<Plug>\zs.*'), 'm')
             return ''
         endif
         " If no completion and there is an original <Tab> mapping, execute it
         if g:ollama_original_tab_mapping.expr
             " rhs is an expression
             call ollama#logger#Info("<tab> expression")
-            return "\<C-R>=" . g:ollama_original_tab_mapping.rhs . "\<CR>"
+            return "\<C-R>=" .. g:ollama_original_tab_mapping.rhs .. "\<CR>"
         else
             " rhs is a string
             call ollama#logger#Info("<tab> string")
@@ -183,7 +183,7 @@ function! s:MapTab() abort
         if !exists('g:ollama_original_tab_mapping') || empty(g:ollama_original_tab_mapping)
             call ollama#logger#Info("Mapping <tab> to vim-ollama")
             let g:ollama_original_tab_mapping = maparg('<Tab>', 'i', 0, 1)
-            call ollama#logger#Info("Original Mapping: " . string(g:ollama_original_tab_mapping))
+            call ollama#logger#Info("Original Mapping: " .. string(g:ollama_original_tab_mapping))
         else
             call ollama#logger#Info("Not mapping <tab> to vim-ollama, because mapping already exists")
         endif


### PR DESCRIPTION
Vim documentation recommends `..` for string concatenation, rather than `.`, as the later can be easily confused as it is also used for dictionary member access and floating point numbers.

Vim9 enhances `..` with auto-conversion to string.