### PR TITLE
Correct language in prompt in edit mode

### DIFF
--- a/python/CodeEditor.py
+++ b/python/CodeEditor.py
@@ -333,7 +333,7 @@ Please rewrite the code between the tags `<START_EDIT_HERE>` and `<STOP_EDIT_HER
     prompt = chat_template.render(messages=chat, add_generation_prompt=True)
     # Start the answer of the assistant to set it on the right path...
     prompt += f"""Sure! Here's the rewritten code block:
-```c
+```{ft}
 {preamble}
 <START_EDIT_HERE>"""
     debug_print(prompt)


### PR DESCRIPTION
Use language name from vim instead of hardcoded "c" in second code block in prompt in edit mode.