### PR TITLE
Fix line numbers calculation for edit and review commands

### DIFF
--- a/autoload/ollama/edit.vim
+++ b/autoload/ollama/edit.vim
@@ -164,22 +164,9 @@ endfunction
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Popup edit prompt, instead of Edit command
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-function! ollama#edit#EditPrompt()
-    " Initialize line numbers
-    let l:firstline = 0
-    let l:lastline = 0
-
-    if mode() ==# 'v' || mode() ==# 'V' || mode() ==# "\<C-V>"
-        " Get the first and last line of the selection
-        let l:firstline = line("'<")
-        let l:lastline = line("'>")
-    else
-        let l:firstline = 1
-        let l:lastline = line('$')
-    endif
-
+function! ollama#edit#EditPrompt() range
     " Extract the selected text or the whole file content
-    let l:selected_text = join(getline(l:firstline, l:lastline), "\n")
+    let l:selected_text = join(getline(a:firstline, a:lastline), "\n")
 
     " Show a prompt to enter the user request
     let l:prompt = input('Enter prompt: ', '', 'file')
@@ -190,7 +177,7 @@ function! ollama#edit#EditPrompt()
     endif
 
     " Call the ollama#edit#EditCodeInternal function with the request and selected context
-    call s:EditCodeInternal(l:prompt, l:firstline, l:lastline)
+    call s:EditCodeInternal(l:prompt, a:firstline, a:lastline)
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/plugin/ollama.vim
+++ b/plugin/ollama.vim
@@ -204,14 +204,14 @@ function! s:MapTab() abort
     inoremap <Plug>(ollama-tab-completion) <C-R>=<SID>HandleTabCompletion()<CR>
     inoremap <Plug>(ollama-insert-line)    <Cmd>call ollama#InsertNextLine()<CR>
     inoremap <Plug>(ollama-insert-word)    <Cmd>call ollama#InsertNextWord()<CR>
-    vnoremap <Plug>(ollama-review)         <Cmd>call ollama#review#Review()<CR>
+    vnoremap <Plug>(ollama-review)         :call ollama#review#Review()<CR>
     nnoremap <Plug>(ollama-toggle)         <Cmd>call ollama#Toggle()<CR>
     nnoremap <Plug>(ollama-accept-changes) <Cmd>call ollama#edit#AcceptCurrent()<CR>
     nnoremap <Plug>(ollama-reject-changes) <Cmd>call ollama#edit#RejectCurrent()<CR>
     nnoremap <Plug>(ollama-accept-all-changes) <Cmd>call ollama#edit#AcceptAll()<CR>
     nnoremap <Plug>(ollama-reject-all-changes) <Cmd>call ollama#edit#RejectAll()<CR>
-    nnoremap <Plug>(ollama-edit)           <Cmd>call ollama#edit#EditPrompt()<CR>
-    vnoremap <Plug>(ollama-edit)           <Cmd>call ollama#edit#EditPrompt()<CR>
+    nnoremap <Plug>(ollama-edit)           :call ollama#edit#EditPrompt()<CR>
+    vnoremap <Plug>(ollama-edit)           :call ollama#edit#EditPrompt()<CR>
 
     if !exists('g:ollama_no_tab_map')
         " Save the existing <Tab> mapping in insert mode


### PR DESCRIPTION
For some reason vim doesn't provide correct info about selected block in <Cmd> mode. It always show previously selected block.

So if you start vim, then select a block from line 10 to 20 and press <leader>e the numbers will be 0-0, when you select second block from line 30 to 40 and press <leader>e for the second time you'll get 10-20.

I'm not very good at vim plugins, but with this patch it works correctly in both visual and normal mode.