### PR TITLE
Ollama: support Ollama running in cloud

### DIFF
--- a/autoload/ollama.vim
+++ b/autoload/ollama.vim
@@ -46,6 +46,31 @@ else
           \ .. " or newer is required to support ghost text (textprop)"
 endif
 
+" Gets the Ollama API key from UNIX pass and caches it as a script local
+" variable
+function! s:GetOllamaApiKey() abort
+    if exists('s:ollama_api_key') && s:ollama_api_key !=# ''
+        return s:ollama_api_key
+    endif
+
+    " Run Python once to retrieve and store the key
+    python3 << EOF
+import vim
+from OllamaCredentials import OllamaCredentials
+
+credentialname = vim.eval('get(g:, "ollama_ollama_credentialname", "")')
+key = ""
+try:
+    key = OllamaCredentials().GetApiKey("ollama", credentialname)
+except Exception as e:
+    vim.command(f'echom "Failed to get Ollama key: {e}"')
+if key:
+    vim.command(f'let s:ollama_api_key = "{key}"')
+EOF
+
+    return s:ollamal_api_key
+endfunction
+
 " Gets the Mistral API key from UNIX pass and caches it as a script local
 " variable
 function! s:GetMistralApiKey() abort
@@ -246,6 +271,11 @@ function! ollama#GetSuggestion(timer)
         if g:ollama_mistral_credentialname != ''
             " add credentialname option for Mistral
             let l:command += [ '-k', g:ollama_mistral_credentialname ]
+        endif
+    elseif g:ollama_model_provider == 'ollama'
+        if g:ollama_ollama_credentialname != ''
+            " add credentialname option for Ollama
+            let l:command += [ '-k', g:ollama_ollama_credentialname ]
         endif
     endif
     call ollama#logger#Debug("command=" .. join(l:command, " "))

--- a/autoload/ollama/config.vim
+++ b/autoload/ollama/config.vim
@@ -11,6 +11,7 @@ let s:fetched = 0
 let s:help_text = {
 \ 'ollama_use_venv': 'Use Python virtual environment',
 \ 'ollama_host': 'Ollama API host URL (default=http://localhost:11434).',
+\ 'ollama_ollama_credentialname': 'Credential name to lookup the Ollama API key in password store',
 \ 'ollama_mistral_baseurl': 'Mistral base URL (default='', which uses the official Mistral API).',
 \ 'ollama_mistral_credentialname': 'Credential name to lookup the Mistral API key in password store',
 \ 'ollama_openai_baseurl': 'OpenAI base URL (default='', which uses the official OpenAI API).',
@@ -87,6 +88,11 @@ function! ollama#config#FetchModels(type) abort
         if g:ollama_mistral_credentialname != ''
             " add credentialname option for Mistral
             let l:command += [ '-k', g:ollama_mistral_credentialname ]
+        endif
+    elseif g:ollama_model_provider == 'ollama'
+        if g:ollama_ollama_credentialname != ''
+            " add credentialname option for Ollama
+            let l:command += [ '-k', g:ollama_ollama_credentialname ]
         endif
     endif
 

--- a/autoload/ollama/edit.vim
+++ b/autoload/ollama/edit.vim
@@ -123,6 +123,8 @@ if provider.startswith('openai'):
 elif provider == 'mistral':
     baseurl = vim.eval('g:ollama_mistral_baseurl')
     credentialname = vim.eval('g:ollama_mistral_credentialname')
+elif provider == 'ollama':
+    credentialname = vim.eval('g:ollama_ollama_credentialname')
 # Access global Vim variables
 settings = {
     'url': baseurl,

--- a/autoload/ollama/review.vim
+++ b/autoload/ollama/review.vim
@@ -165,6 +165,9 @@ function! s:StartChat(lines) abort
     if g:ollama_openai_credentialname != ''
          " add system prompt option
         let l:command += [ '-k', g:ollama_openai_credentialname ]
+    elseif g:ollama_ollama_credentialname != ''
+         " add system prompt option
+        let l:command += [ '-k', g:ollama_ollama_credentialname ]
     endif
 
     " Redirect job's IO to buffer

--- a/python/OllamaCredentials.py
+++ b/python/OllamaCredentials.py
@@ -28,15 +28,18 @@ class OllamaCredentials:
 
         provider = provider.lower().strip()
 
-        # 1. Ollama doesn't require authentication
+        # 1. Ollama (local) doesn't require authentication
         if provider == "ollama":
-            return ""
+            if not credentialname:
+                return ""
 
         # Determine environment variable
         if provider in ("openai", "openai_legacy"):
             env_var = "OPENAI_API_KEY"
         elif provider == "mistral":
             env_var = "MISTRAL_API_KEY"
+        elif provider == "ollama":
+            env_var = "OLLAMA_API_KEY"
         else:
             raise ValueError(f"Unknown provider: {provider}")
 

--- a/python/chat.py
+++ b/python/chat.py
@@ -35,13 +35,20 @@ DEFAULT_MAX_TOKENS = 5000
 
 log = None
 
-async def stream_chat_message_ollama(messages, endpoint, model, options, timeout):
+async def stream_chat_message_ollama(messages, endpoint, model, options, timeout, credentialname):
     """Stream chat responses from Ollama API."""
+    cred = OllamaCredentials()
+    api_key = cred.GetApiKey('ollama', credentialname)
+    # don't trace API keys in production, just a development helper
+    log.debug(f'api_key={api_key}')
     headers = {
         "Content-Type": "application/json",
         "Accept": "*/*",
         "Host": endpoint.split("//")[1].split("/")[0],
     }
+
+    if api_key:
+        headers["Authorization"] = "Bearer " + api_key
 
     data = {
         "model": model,
@@ -165,7 +172,7 @@ async def main(provider, endpoint, model, options, systemprompt, timeout, creden
 
                     if provider == "ollama":
                         task = asyncio.create_task(
-                            stream_chat_message_ollama(conversation_history, endpoint, model, options, timeout)
+                            stream_chat_message_ollama(conversation_history, endpoint, model, options, timeout, credentialname)
                         )
                     else:
                         task = asyncio.create_task(
@@ -185,14 +192,13 @@ async def main(provider, endpoint, model, options, systemprompt, timeout, creden
                     conversation_history.append({"role": "user", "content": user_message})
                     if provider == "ollama":
                         task = asyncio.create_task(
-                            stream_chat_message_ollama(conversation_history, endpoint, model, options, timeout)
+                            stream_chat_message_ollama(conversation_history, endpoint, model, options, timeout, credentialname)
                         )
                     else:
                         task = asyncio.create_task(
                             stream_chat_message_openai(conversation_history, endpoint, model, options, credentialname)
                         )
                     await task
-
         except KeyboardInterrupt:
             print("\nStreaming interrupted. Showing prompt again...")
             if "task" in locals():

--- a/python/complete.py
+++ b/python/complete.py
@@ -106,13 +106,21 @@ def fill_in_the_middle(config, prompt):
 
     return newprompt
 
-def generate_code_completion(config, prompt, baseurl, model, options):
+def generate_code_completion(config, prompt, baseurl, model, options, credentialname):
     """ Code completion using Ollama REST API """
+    cred = OllamaCredentials()
+    api_key = cred.GetApiKey('ollama', credentialname)
+    # don't trace API keys in production, just a development helper
+    log.debug(f'api_key={api_key}')
     headers = {
         'Content-Type': 'application/json',
         'Accept': '*/*',
         'Host': baseurl.split('//')[1].split('/')[0]
     }
+
+    if api_key:
+        headers["Authorization"] = "Bearer " + api_key
+
     endpoint = baseurl + "/api/generate"
     log.debug('endpoint: ' + endpoint)
 
@@ -403,7 +411,7 @@ if __name__ == "__main__":
                 modelname = DEFAULT_MODEL
             baseurl = args.url or DEFAULT_HOST
             config = load_config(modelname) if USE_CUSTOM_TEMPLATE else None
-            response = generate_code_completion(config, prompt, baseurl, modelname, options)
+            response = generate_code_completion(config, prompt, baseurl, modelname, options, args.keyname)
         elif args.provider == "mistral":
             if args.model:
                 modelname = args.model


### PR DESCRIPTION
By adding support for

let g:ollama_ollama_credentialname = 'api-keys/ollama-key'

it is possible to support

https://ollama.com:443 as ollama host