### PR TITLE
Introduce variable to allow skipping setup

### DIFF
--- a/autoload/ollama/setup.vim
+++ b/autoload/ollama/setup.vim
@@ -469,6 +469,10 @@ endfunction
 function! ollama#setup#Init() abort
     let l:ollama_config = expand('$HOME/.vim/config/ollama.vim')
 
+    if exists('g:ollama_skip_setup') && g:ollama_skip_setup
+        return
+    endif
+
     " check if config file exists
     if !filereadable(l:ollama_config)
         echon "Welcome to Vim-Ollama!\n"


### PR DESCRIPTION
By setting
let g:ollama_skip_setup = 1
you can skip the setup, this is useful in situation when you have no .vim/config/ollama.vim like on my nixos setup:
https://codeberg.org/asoderq/nixos-config/src/branch/main/roles/vim.nix